### PR TITLE
Fix accept-button=“false” not hiding accept button.

### DIFF
--- a/src/js/directives/banner.js
+++ b/src/js/directives/banner.js
@@ -24,7 +24,7 @@ angular.module('angular-cookie-law')
 
             options = {
               message: attr.message || 'We use cookies to track usage and preferences.', //Message displayed on bar
-              acceptButton: attr.acceptButton || true, //Set to true to show accept/enable button
+              acceptButton: attr.acceptButton === 'false' ? false : true, //Set to true to show accept/enable button
               acceptText: attr.acceptText || 'I Understand', //Text on accept/enable button
               declineButton: attr.declineButton || false, //Set to true to show decline/disable button
               declineText: attr.declineText || 'Disable Cookies', //Text on decline/disable button


### PR DESCRIPTION
The directive is failing to recognise the accept-button="false" attribute because it's a string and not a boolean.