### PR TITLE
Add possibility to control position of the banner.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ angular.module('myApp', ['angular-cookie-law']);
 You could insert this directive at the beginning of `<body>` tag.
 
 ```html
-<cookie-law-banner message="Your custon message" policy-url="http://link-to-your-policy"></cookie-law-banner>
+<cookie-law-banner position="top" message="Your custon message" policy-url="http://link-to-your-policy"></cookie-law-banner>
 ```
 
 This directive creates a banner that informs users about cookies that contains a button to accept them.
@@ -51,6 +51,14 @@ This directive creates a banner that informs users about cookies that contains a
 ### Options
 
 From version 0.2.0, all banner texts are refreshed if one of these attributes change: **message**, **acceptText**, **declineText**, **policyText**, **policyURL**.
+
+#### position 
+
+```
+position: 'top'
+```
+
+Position of the banner (variants: "top", "bottom". default: "top").
 
 #### message
 

--- a/src/css/angular-cookie-law.css
+++ b/src/css/angular-cookie-law.css
@@ -9,9 +9,16 @@
   z-index: 10000;
 
   position: fixed;
-  top: 0;
   left: 0;
   width: 100%;
+}
+
+.cl-banner.top {
+  top: 0;
+}
+
+.cl-banner.bottom {
+  bottom: 0;
 }
 
 /*

--- a/src/js/directives/banner.js
+++ b/src/js/directives/banner.js
@@ -5,6 +5,7 @@ angular.module('angular-cookie-law')
         restrict: 'EA',
         replace: true,
         scope: {
+          position: '@',
           message: '@',
           acceptText: '@',
           declineText: '@',
@@ -17,12 +18,13 @@ angular.module('angular-cookie-law')
               declineButton = '',
               policyButton = '';
 
-          scope.$watchGroup(['message', 'acceptText', 'declineText', 'policyText', 'policyURL'], function() {
+          scope.$watchGroup(['position', 'message', 'acceptText', 'declineText', 'policyText', 'policyURL'], function() {
             if (CookieLawService.isEnabled()) {
               return;
             }
 
             options = {
+              position: attr.position === 'bottom' ? 'bottom' : 'top', //Position of the banner. (Default: 'top')
               message: attr.message || 'We use cookies to track usage and preferences.', //Message displayed on bar
               acceptButton: attr.acceptButton === 'false' ? false : true, //Set to true to show accept/enable button
               acceptText: attr.acceptText || 'I Understand', //Text on accept/enable button
@@ -55,7 +57,7 @@ angular.module('angular-cookie-law')
             }
 
             template =
-              '<div class="cl-banner"><p>' + options.message + '<br>' + acceptButton + declineButton + policyButton + '</p></div>';
+              '<div class="cl-banner ' + options.position + '"><p>' + options.message + '<br>' + acceptButton + declineButton + policyButton + '</p></div>';
 
             element.html(template);
             $compile(element.contents())(scope);


### PR DESCRIPTION
Hi,

I've added a possibility to control position of the banner. 

You will be able to show it on the bottom of a page now:

    <cookie-law-banner position="bottom"></cookie-law-banner>

Or on the top, as it was before:

    <cookie-law-banner position="top"></cookie-law-banner>

`top` position is by default. 

Thanks.