### PR TITLE
Changed "main" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cookie law",
     "banner"
   ],
-  "main": "gulpfile.js",
+  "main": "dist/angular-cookie-law.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The purpose of "main" field is to point to the main script file; gulpfile is not a main script.