### PR TITLE
Fix the error about undeclared variables

### DIFF
--- a/src/js/directives/banner.js
+++ b/src/js/directives/banner.js
@@ -19,7 +19,7 @@ angular.module('angular-cookie-law')
           element: '@',
         },
         link: function (scope, element, attr) {
-          var template, options, expireDate;
+          var template, options, expireDate, acceptButton = '', declineButton = '', policyButton = '';
 
           scope.$watchGroup([
             'position',


### PR DESCRIPTION
Resolve the error "ReferenceError: declineButton is not defined" by declaring used variables.